### PR TITLE
Support git submodules; Add "always" option; Fix compatibility with ESPHome 2024.3.1 and later; Update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ All of them are **optional**.
 - **unversioned** (String, default=`-UNVERSIONED`): Suffix to append when the device config file is not tracked by Git.
 
 ### Dirty parsing
+
 When using the `dirty` option, _only_ **tracked** files that are relevant for the configuration are considered!
   
 This includes the following:
@@ -56,3 +57,4 @@ This includes the following:
 
 If there are uncommitted changes to any of these files, the provided `dirty` suffix will be added to the `git describe` output.
 
+When git submodules are included, the detection which files are actually used is currently not implemented and dirty is reporeted if any file or even a file in a git submodules has uncommitted changes.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ external_components:
 
 text_sensor:
   - platform: git_ref
-    name: "${friendly_name} Git Ref"
+    name: "Git Ref"
     long: true
     all: true
     abbrev: 16

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All of them are **optional**.
 
 - **abbrev** (Int): Instead of using the default number of hexadecimal digits (which will vary according to the number of objects in the repository with a default of 7) of the abbreviated object name, use <n> digits, or as many digits as needed to form a unique object name. An <n> of 0 will suppress long format, only showing the closest tag.
 - **all** (Boolean): Instead of using only the annotated tags, use any ref found in refs/ namespace. This option enables matching any known branch, remote-tracking branch, or lightweight tag.
+- **always** (Boolean): Show uniquely abbreviated commit object as fallback. Useful to avoid the "No names found, cannot describe anything." error in case no git tag exists.
 - **broken** (String): Describe the state of the working tree. If a repository is corrupt and Git cannot determine if there is local modification, Git will error out, unless ‘--broken’ is given, which appends the suffix provided by this option instead.
 - **commit-ish** (String): Commit-ish object names to describe. Defaults to HEAD if omitted.
 - **dirty** (String): Describe the state of the working tree[<sup>[1]</sup>](#dirty-parsing). If the working tree has local modifications the suffix provided by this option is appended to it.

--- a/components/git_ref/text_sensor.py
+++ b/components/git_ref/text_sensor.py
@@ -35,6 +35,7 @@ CONFIG_SCHEMA = (
             cv.Optional("all", default=False): cv.boolean,
             cv.Optional("tags", default=False): cv.boolean,
             cv.Optional("long", default=False): cv.boolean,
+            cv.Optional("always", default=False): cv.boolean,
             cv.Optional("abbrev"): cv.positive_int,
         }
     )
@@ -237,6 +238,8 @@ def produce_git_describe(config):
         COMMAND.append("--tags")
     if config.get("long", False):
         COMMAND.append("--long")
+    if config.get("always", False):
+        COMMAND.append("--always")
 
     if "abbrev" in config:
         COMMAND.append(f"--abbrev={config['abbrev']}")

--- a/components/git_ref/text_sensor.py
+++ b/components/git_ref/text_sensor.py
@@ -4,7 +4,6 @@ import re
 import yaml
 
 from esphome import git, yaml_util, util
-from esphome.config_helpers import read_config_file
 
 from esphome.core import CORE
 from esphome.components import text_sensor

--- a/example.yaml
+++ b/example.yaml
@@ -8,7 +8,7 @@ esp32:
   board: wemos_d1_mini32
   framework:
     type: arduino
-  
+
 external_components:
   - source: github://RoboMagus/esphome-gitref-sensor
 
@@ -26,7 +26,7 @@ ota:
 
 text_sensor:
   - platform: git_ref
-    name: "${friendly_name} Git Ref"
+    name: "Git Ref"
     long: true
     all: true
     abbrev: 16


### PR DESCRIPTION
PS: Awesome component, exactly what I was looking for! Not a lot of people seem to care about features like that which improve tracing/auditing/debugging. But yeah, maybe that is also the [enterprise smart home syndrome](https://frenck.dev/the-enterprise-smart-home-syndrome/)? I work in IT also of course ;-)

PPS: You might also be interested in [Reproducible Builds](https://reproducible-builds.org/). My goal is to use Nix to build my firmware fully reproducible. [`esphome` is packaged in Nixpkgs](https://search.nixos.org/packages?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=esphome) so that is a start.