### PR TITLE
Support git submodules in dirty. Used files detection not yet implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All of them are **optional**.
 - **unversioned** (String, default=`-UNVERSIONED`): Suffix to append when the device config file is not tracked by Git.
 
 ### Dirty parsing
+
 When using the `dirty` option, _only_ **tracked** files that are relevant for the configuration are considered!
   
 This includes the following:
@@ -55,3 +56,4 @@ This includes the following:
 
 If there are uncommitted changes to any of these files, the provided `dirty` suffix will be added to the `git describe` output.
 
+When git submodules are included, the detection which files are actually used is currently not implemented and dirty is reporeted if any file or even a file in a git submodules has uncommitted changes.

--- a/components/git_ref/text_sensor.py
+++ b/components/git_ref/text_sensor.py
@@ -66,6 +66,15 @@ def is_config_versioned():
     return git_ls_files == config_path_trimmed
 
 
+def is_superproject_using_git_submodules():
+    GIT_SUBMODULES = git.run_git_command(
+        ["git", "submodule", "status", "--cached"],
+    )
+    _LOGGER.debug("git submodules: %s", GIT_SUBMODULES)
+
+    return GIT_SUBMODULES != ""
+
+
 def get_git_diff(GIT_DIR, cached=False):
     DIFF_COMMAND = ["git", "diff", "--name-only"]
     if cached:
@@ -249,17 +258,22 @@ def produce_git_describe(config):
     if "dirty" in config:
         # COMMAND.append(f"--dirty={config['dirty']}")
         if is_config_versioned():
-            diff_paths = get_git_diff_file_paths(config)
-            config_paths = get_config_file_paths(config)
-            _LOGGER.info(
-                "Checking git Diffs: \n%s\n\nAgainst files in config: \n%s\n",
-                diff_paths,
-                config_paths,
-            )
-            for file in config_paths:
-                if file in diff_paths:
-                    dirty_postfix = config["dirty"]
-                    _LOGGER.warning("Config dirty: '%s' has changes", file)
+            if is_superproject_using_git_submodules():
+                # Git submodules are involved. Using simplified dirty status
+                # that does not check what files are actually used.
+                COMMAND.append(f"--dirty={config['dirty']}")
+            else:
+                diff_paths = get_git_diff_file_paths(config)
+                config_paths = get_config_file_paths(config)
+                _LOGGER.info(
+                    "Checking git Diffs: \n%s\n\nAgainst files in config: \n%s\n",
+                    diff_paths,
+                    config_paths,
+                )
+                for file in config_paths:
+                    if file in diff_paths:
+                        dirty_postfix = config["dirty"]
+                        _LOGGER.warning("Config dirty: '%s' has changes", file)
         else:
             _LOGGER.warning("Config File '%s' is unversioned!", CORE.config_path)
             dirty_postfix = config["unversioned"]


### PR DESCRIPTION
Continuing the discussion from #1:

I currently don’t have the time to implemented used file detection for git submodules so I open this as draft PR. I am used to commit before I build so for me it is more natural that dirty reflects all files. But I like the idea of dirty being smarter. My idea long-term plan is to build ESPHome firmware in CI using a known (non-dirty) git state anyway so also for that, I don’t need the smartness. So I am not sure when I come around to finish this PR. Other people are welcome to finish it.