### PR TITLE
Fix compatibility with ESPHome 2024.3.1 and later

### DIFF
--- a/components/git_ref/text_sensor.py
+++ b/components/git_ref/text_sensor.py
@@ -4,7 +4,6 @@ import re
 import yaml
 
 from esphome import git, yaml_util, util
-from esphome.config_helpers import read_config_file
 
 from esphome.core import CORE
 from esphome.components import text_sensor


### PR DESCRIPTION
[`read_config_file` has been removed on 2024-03-26 from ESPHome source code](https://github.com/esphome/esphome/commit/f00d8760807b9def3e837ccfa32d49faf73f9943#diff-547d7b08834621f8c0b2e0a14608b313bf9a4e8ebcb3fd291e80d3c7a306a5c0L41-L59). It is an unused import thus it is just removed.