### PR TITLE
Fix "'ESP_LOGCONFIG' was not declared in this scope" error

### DIFF
--- a/components/git_ref/git_ref_sensor.h
+++ b/components/git_ref/git_ref_sensor.h
@@ -2,6 +2,7 @@
 
 #include "esphome/core/helpers.h"
 #include "esphome/core/component.h"
+#include "esphome/core/log.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 
 namespace esphome {
@@ -33,5 +34,5 @@ class GitRefTextSensor : public text_sensor::TextSensor, public PollingComponent
   static constexpr const char * TAG = "GitRefSensor";
 };
 
-}  // namespace jga25_371_cover
+}  // namespace git_ref
 }  // namespace esphome


### PR DESCRIPTION
It worked previously because the include order is not fixed I guess and some other component always included `log.h` before git_ref.

```
In file included from src/esphome.h:10,
                 from src/main.cpp:3:
src/esphome/components/git_ref/git_ref_sensor.h: In member function 'virtual void esphome::git_ref::GitRefTextSensor::dump_con
fig()':
src/esphome/components/git_ref/git_ref_sensor.h:27:5: error: 'ESP_LOGCONFIG' was not declared in this scope
   27 |     ESP_LOGCONFIG(TAG, "GitRefTextSensor:");
      |     ^~~~~~~~~~~~~
src/esphome/components/git_ref/git_ref_sensor.h:27:5: note: the macro 'ESP_LOGCONFIG' had not yet been defined                In file included from src/esphome/components/sensor/sensor.h:3,
                 from src/esphome/components/internal_temperature/internal_temperature.h:4,
                 from src/esphome.h:11:
src/esphome/core/log.h:155: note: it was later defined here
  155 | #define ESP_LOGCONFIG(tag, ...) esph_log_config(tag, __VA_ARGS__)
      |
```

```
$ head .esphome/build/my-sensor/src/esphome.h -n 20
#pragma once
#include "esphome/core/macros.h"
#include "esphome/components/binary_sensor/automation.h"
#include "esphome/components/binary_sensor/binary_sensor.h"
#include "esphome/components/binary_sensor/filter.h"
#include "esphome/components/button/automation.h"
#include "esphome/components/button/button.h"
#include "esphome/components/esp32/gpio.h"
#include "esphome/components/esp32/preferences.h"
#include "esphome/components/git_ref/git_ref_sensor.h"
#include "esphome/components/internal_temperature/internal_temperature.h"
#include "esphome/components/logger/logger.h"
```